### PR TITLE
Add starter Godot scenes and gameplay scaffolding

### DIFF
--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,0 +1,19 @@
+[gd_resource type="AudioBusLayout" format=3]
+
+[resource]
+bus_count = 3
+bus/0/name = "Master"
+bus/0/solo = false
+bus/0/mute = false
+bus/0/volume_db = 0.0
+bus/0/send = ""
+bus/1/name = "Music"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/volume_db = 0.0
+bus/1/send = "Master"
+bus/2/name = "SFX"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/volume_db = 0.0
+bus/2/send = "Master"

--- a/project.godot
+++ b/project.godot
@@ -10,6 +10,16 @@ config_version=5
 
 [application]
 
-config/name="Aperature 9"
+config/name="Aperture Nine"
 config/features=PackedStringArray("4.5", "Forward Plus")
 config/icon="res://icon.svg"
+run/main_scene="res://scenes/Title.tscn"
+
+[audio]
+
+bus/layout="res://default_bus_layout.tres"
+
+[autoload]
+
+GameSettings="*res://scripts/GameSettings.gd"
+ProfileManager="*res://scripts/ProfileManager.gd"

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,50 @@
+[gd_scene load_steps=14 format=3]
+
+[ext_resource type="Script" path="res://scripts/GameManager.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/CameraNetwork.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/NPCSpawner.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/TargetManager.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/Scanner.gd" id="5"]
+[ext_resource type="Script" path="res://scripts/SnapshotManager.gd" id="6"]
+[ext_resource type="PackedScene" path="res://ui/HUD.tscn" id="7"]
+[ext_resource type="PackedScene" path="res://ui/MiniMap.tscn" id="8"]
+[ext_resource type="PackedScene" path="res://ui/StaticOverlay.tscn" id="9"]
+[ext_resource type="PackedScene" path="res://ui/PauseMenu.tscn" id="10"]
+[ext_resource type="PackedScene" path="res://ui/SummaryPanel.tscn" id="11"]
+[ext_resource type="PackedScene" path="res://ui/SettingsPanel.tscn" id="12"]
+[ext_resource type="PackedScene" path="res://ui/ControlsOverlay.tscn" id="13"]
+[ext_resource type="PackedScene" path="res://ui/ProfilePanel.tscn" id="14"]
+
+[node name="Main" type="Node"]
+script = ExtResource("1")
+
+[node name="CameraNetwork" type="Node" parent="."]
+script = ExtResource("2")
+
+[node name="NPCSpawner" type="Node" parent="."]
+script = ExtResource("3")
+
+[node name="TargetManager" type="Node" parent="."]
+script = ExtResource("4")
+
+[node name="Scanner" type="Node" parent="."]
+script = ExtResource("5")
+
+[node name="SnapshotManager" type="Node" parent="."]
+script = ExtResource("6")
+
+[node name="HUD" parent="." instance=ExtResource("7")]
+
+[node name="MiniMap" parent="." instance=ExtResource("8")]
+
+[node name="StaticOverlay" parent="." instance=ExtResource("9")]
+
+[node name="PauseMenu" parent="." instance=ExtResource("10")]
+
+[node name="SummaryPanel" parent="." instance=ExtResource("11")]
+
+[node name="SettingsPanel" parent="." instance=ExtResource("12")]
+
+[node name="ControlsOverlay" parent="." instance=ExtResource("13")]
+
+[node name="ProfilePanel" parent="." instance=ExtResource("14")]

--- a/scenes/Title.tscn
+++ b/scenes/Title.tscn
@@ -1,0 +1,44 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Title.gd" id="1"]
+[ext_resource type="PackedScene" path="res://ui/SettingsPanel.tscn" id="2"]
+
+[node name="Title" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0.0705882, 0.0666667, 0.0980392, 1)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 64
+custom_constants/margin_top = 64
+custom_constants/margin_right = 64
+custom_constants/margin_bottom = 64
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+size_flags_vertical = 3
+separation = 32
+
+[node name="TitleLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+text = "Aperture Nine"
+custom_minimum_size = Vector2(0, 80)
+vertical_alignment = 1
+horizontal_alignment = 1
+
+[node name="StartButton" type="Button" parent="MarginContainer/VBoxContainer"]
+text = "Begin Shift"
+
+[node name="SettingsButton" type="Button" parent="MarginContainer/VBoxContainer"]
+text = "Settings"
+
+[node name="QuitButton" type="Button" parent="MarginContainer/VBoxContainer"]
+text = "Exit"
+
+[node name="SettingsPanelInstance" parent="." instance=ExtResource("2")]
+position = Vector2(32, 32)

--- a/scripts/CameraNetwork.gd
+++ b/scripts/CameraNetwork.gd
@@ -1,0 +1,29 @@
+extends Node
+class_name CameraNetwork
+
+## Handles switching between the nine surveillance cameras.
+
+signal active_camera_changed(index: int)
+
+@export var camera_count := 9
+var _active_index := 0
+
+func _ready() -> void:
+    active_camera_changed.emit(_active_index)
+
+func activate_next() -> void:
+    set_active((_active_index + 1) % camera_count)
+
+func activate_previous() -> void:
+    set_active((_active_index - 1 + camera_count) % camera_count)
+
+func set_active(index: int) -> void:
+    index = clamp(index, 0, camera_count - 1)
+    if index == _active_index:
+        return
+    _active_index = index
+    active_camera_changed.emit(_active_index)
+    ProfileManager.record_camera_index(_active_index)
+
+func get_active() -> int:
+    return _active_index

--- a/scripts/ControlsOverlay.gd
+++ b/scripts/ControlsOverlay.gd
@@ -1,0 +1,10 @@
+extends Control
+class_name ControlsOverlay
+
+## Displays the current input bindings.
+
+func show_overlay() -> void:
+    visible = true
+
+func hide_overlay() -> void:
+    visible = false

--- a/scripts/GameManager.gd
+++ b/scripts/GameManager.gd
@@ -1,0 +1,111 @@
+extends Node
+class_name GameManager
+
+## Coordinates the relationship between the main gameplay systems.
+
+@export var shift_length_seconds := 600.0
+
+var _shift_time_remaining := 0.0
+var _shift_active := false
+
+@onready var camera_network: Node = get_node_or_null("CameraNetwork")
+@onready var npc_spawner: Node = get_node_or_null("NPCSpawner")
+@onready var target_manager: Node = get_node_or_null("TargetManager")
+@onready var scanner: Node = get_node_or_null("Scanner")
+@onready var snapshot_manager: Node = get_node_or_null("SnapshotManager")
+@onready var hud: CanvasItem = get_node_or_null("HUD")
+@onready var mini_map: CanvasItem = get_node_or_null("MiniMap")
+@onready var static_overlay: CanvasItem = get_node_or_null("StaticOverlay")
+@onready var pause_menu: PauseMenu = get_node_or_null("PauseMenu")
+@onready var summary_panel: CanvasItem = get_node_or_null("SummaryPanel")
+@onready var settings_panel: SettingsPanel = get_node_or_null("SettingsPanel")
+@onready var controls_overlay: ControlsOverlay = get_node_or_null("ControlsOverlay")
+@onready var profile_panel: ProfilePanel = get_node_or_null("ProfilePanel")
+
+func _ready() -> void:
+    _shift_time_remaining = shift_length_seconds
+    set_process(true)
+    if Engine.is_editor_hint():
+        return
+    _prepare_ui_state()
+    _connect_signals()
+    start_shift()
+
+func _process(delta: float) -> void:
+    if not _shift_active:
+        return
+    _shift_time_remaining = max(0.0, _shift_time_remaining - delta)
+    if hud:
+        hud.call_deferred("update_timer", _shift_time_remaining)
+    if _shift_time_remaining == 0.0:
+        end_shift()
+
+func start_shift() -> void:
+    _shift_time_remaining = shift_length_seconds
+    _shift_active = true
+    if hud:
+        hud.call_deferred("show_gameplay")
+    if mini_map:
+        mini_map.visible = true
+    if static_overlay:
+        static_overlay.visible = true
+    if profile_panel:
+        profile_panel.visible = false
+    if summary_panel:
+        summary_panel.visible = false
+
+func end_shift() -> void:
+    if not _shift_active:
+        return
+    _shift_active = false
+    if summary_panel:
+        summary_panel.call_deferred("show_summary")
+    if profile_panel:
+        profile_panel.visible = true
+        profile_panel.call_deferred("refresh")
+
+func toggle_pause() -> void:
+    if get_tree().paused:
+        _on_resume_requested()
+    else:
+        get_tree().paused = true
+        if pause_menu:
+            pause_menu.visible = true
+
+func _prepare_ui_state() -> void:
+    if hud:
+        hud.call_deferred("show_title")
+    for node in [mini_map, static_overlay, pause_menu, summary_panel, settings_panel, controls_overlay, profile_panel]:
+        if node:
+            node.visible = false
+
+func _connect_signals() -> void:
+    if camera_network and mini_map and camera_network.has_signal("active_camera_changed"):
+        camera_network.active_camera_changed.connect(mini_map.set_active_camera)
+    if pause_menu:
+        pause_menu.resume_requested.connect(_on_resume_requested)
+        pause_menu.settings_requested.connect(_on_pause_settings_requested)
+        pause_menu.controls_requested.connect(_on_pause_controls_requested)
+        pause_menu.quit_requested.connect(_on_pause_quit_requested)
+    if camera_network and static_overlay and camera_network.has_signal("active_camera_changed") and static_overlay.has_method("flash"):
+        camera_network.active_camera_changed.connect(func(_index: int) -> void: static_overlay.flash())
+
+func _on_resume_requested() -> void:
+    get_tree().paused = false
+    if pause_menu:
+        pause_menu.visible = false
+    if settings_panel:
+        settings_panel.visible = false
+    if controls_overlay:
+        controls_overlay.visible = false
+
+func _on_pause_settings_requested() -> void:
+    if settings_panel:
+        settings_panel.visible = not settings_panel.visible
+
+func _on_pause_controls_requested() -> void:
+    if controls_overlay:
+        controls_overlay.visible = not controls_overlay.visible
+
+func _on_pause_quit_requested() -> void:
+    get_tree().quit()

--- a/scripts/GameSettings.gd
+++ b/scripts/GameSettings.gd
@@ -1,0 +1,89 @@
+extends Node
+class_name GameSettings
+
+## Autoload responsible for storing and applying runtime settings.
+##
+## The current implementation focuses on persisting difficulty, crowd size,
+## fullscreen, and audio levels. It intentionally keeps the surface area small
+## so the rest of the project can grow around a stable API.
+
+const SETTINGS_PATH := "user://settings.cfg"
+
+var difficulty := "Normal"
+var crowd_size := 10
+var full_screen := false
+var volume_master_db := 0.0
+var volume_music_db := -6.0
+var volume_sfx_db := -6.0
+
+func _ready() -> void:
+    load_settings()
+    _apply_video_settings()
+    _apply_audio_settings()
+
+func load_settings() -> void:
+    var config := ConfigFile.new()
+    var result := config.load(SETTINGS_PATH)
+    if result != OK:
+        save_settings()
+        return
+
+    difficulty = config.get_value("game", "difficulty", difficulty)
+    crowd_size = int(config.get_value("game", "crowd_size", crowd_size))
+    full_screen = bool(config.get_value("video", "full_screen", full_screen))
+    volume_master_db = float(config.get_value("audio", "volume_master_db", volume_master_db))
+    volume_music_db = float(config.get_value("audio", "volume_music_db", volume_music_db))
+    volume_sfx_db = float(config.get_value("audio", "volume_sfx_db", volume_sfx_db))
+
+func save_settings() -> void:
+    var config := ConfigFile.new()
+    config.set_value("game", "difficulty", difficulty)
+    config.set_value("game", "crowd_size", crowd_size)
+    config.set_value("video", "full_screen", full_screen)
+    config.set_value("audio", "volume_master_db", volume_master_db)
+    config.set_value("audio", "volume_music_db", volume_music_db)
+    config.set_value("audio", "volume_sfx_db", volume_sfx_db)
+    config.save(SETTINGS_PATH)
+
+func apply_and_save() -> void:
+    _apply_video_settings()
+    _apply_audio_settings()
+    save_settings()
+
+func set_full_screen(enabled: bool) -> void:
+    full_screen = enabled
+    _apply_video_settings()
+
+func set_difficulty(value: String) -> void:
+    difficulty = value
+    save_settings()
+
+func set_crowd_size(value: int) -> void:
+    crowd_size = max(1, value)
+    save_settings()
+
+func set_audio_levels(master_db: float, music_db: float, sfx_db: float) -> void:
+    volume_master_db = master_db
+    volume_music_db = music_db
+    volume_sfx_db = sfx_db
+    _apply_audio_settings()
+    save_settings()
+
+func _apply_video_settings() -> void:
+    if full_screen:
+        DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+    else:
+        DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+
+func _apply_audio_settings() -> void:
+    var master_bus := AudioServer.get_bus_index("Master")
+    if master_bus != -1:
+        AudioServer.set_bus_volume_db(master_bus, volume_master_db)
+
+    var music_bus := AudioServer.get_bus_index("Music")
+    if music_bus != -1:
+        AudioServer.set_bus_volume_db(music_bus, volume_music_db)
+
+    var sfx_bus := AudioServer.get_bus_index("SFX")
+    if sfx_bus != -1:
+        AudioServer.set_bus_volume_db(sfx_bus, volume_sfx_db)

--- a/scripts/HUD.gd
+++ b/scripts/HUD.gd
@@ -1,0 +1,23 @@
+extends Control
+class_name HUD
+
+## Displays core gameplay information like the timer and prompts.
+
+@onready var timer_label: Label = $MarginContainer/VBoxContainer/TimerLabel
+@onready var message_label: Label = $MarginContainer/VBoxContainer/MessageLabel
+
+func show_title() -> void:
+    message_label.text = "Awaiting HQ directive"
+    timer_label.text = format_time(0.0)
+
+func show_gameplay() -> void:
+    message_label.text = "Shift live"
+
+func update_timer(time_remaining: float) -> void:
+    timer_label.text = format_time(time_remaining)
+
+func format_time(time_remaining: float) -> String:
+    var seconds := int(round(time_remaining))
+    var minutes := seconds / 60
+    var secs := seconds % 60
+    return "%02d:%02d" % [minutes, secs]

--- a/scripts/MiniMap.gd
+++ b/scripts/MiniMap.gd
@@ -1,0 +1,12 @@
+extends Control
+class_name MiniMap
+
+## Highlights the currently active camera in the network.
+
+@onready var indicator_container: GridContainer = $MarginContainer/GridContainer
+
+func set_active_camera(index: int) -> void:
+    for child_index in indicator_container.get_child_count():
+        var child := indicator_container.get_child(child_index)
+        if child is Button:
+            child.button_pressed = child_index == index

--- a/scripts/NPCSpawner.gd
+++ b/scripts/NPCSpawner.gd
@@ -1,0 +1,27 @@
+extends Node
+class_name NPCSpawner
+
+## Responsible for maintaining the active crowd.
+
+@export var spawn_count := 10
+var _spawned_characters: Array = []
+
+func _ready() -> void:
+    if Engine.is_editor_hint():
+        return
+    randomize()
+    spawn_count = GameSettings.crowd_size
+    populate_crowd()
+
+func populate_crowd() -> void:
+    clear_crowd()
+    for i in spawn_count:
+        _spawned_characters.append({"id": i})
+
+func clear_crowd() -> void:
+    _spawned_characters.clear()
+
+func get_random_subject() -> Dictionary:
+    if _spawned_characters.is_empty():
+        return {}
+    return _spawned_characters[randi() % _spawned_characters.size()]

--- a/scripts/PauseMenu.gd
+++ b/scripts/PauseMenu.gd
@@ -1,0 +1,21 @@
+extends Control
+class_name PauseMenu
+
+## Basic pause menu shell that can resume gameplay.
+
+@onready var resume_button: Button = $MarginContainer/VBoxContainer/ResumeButton
+@onready var settings_button: Button = $MarginContainer/VBoxContainer/SettingsButton
+@onready var controls_button: Button = $MarginContainer/VBoxContainer/ControlsButton
+@onready var quit_button: Button = $MarginContainer/VBoxContainer/QuitButton
+
+signal resume_requested
+signal settings_requested
+signal controls_requested
+signal quit_requested
+
+func _ready() -> void:
+    visible = false
+    resume_button.pressed.connect(func() -> void: resume_requested.emit())
+    settings_button.pressed.connect(func() -> void: settings_requested.emit())
+    controls_button.pressed.connect(func() -> void: controls_requested.emit())
+    quit_button.pressed.connect(func() -> void: quit_requested.emit())

--- a/scripts/ProfileManager.gd
+++ b/scripts/ProfileManager.gd
@@ -1,0 +1,77 @@
+extends Node
+class_name ProfileManager
+
+## Autoload that manages persistent player progress and statistics.
+
+const PROFILE_PATH := "user://profile.json"
+
+var best_score: Dictionary = {}
+var last_camera_index := 0
+var totals := {
+    "matches": {
+        "correct": 0,
+        "false": 0,
+        "missed": 0,
+    },
+    "photos": {
+        "good": 0,
+        "total": 0,
+    },
+}
+
+func _ready() -> void:
+    load_profile()
+
+func load_profile() -> void:
+    if not FileAccess.file_exists(PROFILE_PATH):
+        save_profile()
+        return
+
+    var file := FileAccess.open(PROFILE_PATH, FileAccess.READ)
+    var result := JSON.parse_string(file.get_as_text())
+    if typeof(result) != TYPE_DICTIONARY:
+        push_warning("Profile data was not a dictionary; resetting to defaults.")
+        save_profile()
+        return
+
+    best_score = result.get("best_score", best_score)
+    last_camera_index = int(result.get("last_camera_index", last_camera_index))
+    var totals_data := result.get("totals", totals)
+    if typeof(totals_data) == TYPE_DICTIONARY:
+        totals = totals_data
+
+func save_profile() -> void:
+    var file := FileAccess.open(PROFILE_PATH, FileAccess.WRITE)
+    var data := {
+        "best_score": best_score,
+        "last_camera_index": last_camera_index,
+        "totals": totals,
+    }
+    file.store_string(JSON.stringify(data, "\t"))
+
+func update_best_score(difficulty: String, score: int) -> void:
+    var current_best := int(best_score.get(difficulty, 0))
+    if score > current_best:
+        best_score[difficulty] = score
+        save_profile()
+
+func record_camera_index(index: int) -> void:
+    last_camera_index = index
+    save_profile()
+
+func record_match_result(result_type: String) -> void:
+    var matches := totals.get("matches", {})
+    if not matches.has(result_type):
+        push_warning("Unknown match result type: %s" % result_type)
+        return
+    matches[result_type] = int(matches[result_type]) + 1
+    totals["matches"] = matches
+    save_profile()
+
+func record_photo(good: bool) -> void:
+    var photos := totals.get("photos", {})
+    photos["total"] = int(photos.get("total", 0)) + 1
+    if good:
+        photos["good"] = int(photos.get("good", 0)) + 1
+    totals["photos"] = photos
+    save_profile()

--- a/scripts/ProfilePanel.gd
+++ b/scripts/ProfilePanel.gd
@@ -1,0 +1,28 @@
+extends Control
+class_name ProfilePanel
+
+## Shows persistent profile information from the ProfileManager.
+
+@onready var best_score_label: Label = $MarginContainer/VBoxContainer/BestScoreLabel
+@onready var totals_label: Label = $MarginContainer/VBoxContainer/TotalsLabel
+
+func refresh() -> void:
+    var best_score_lines := []
+    var difficulties := ProfileManager.best_score.keys()
+    difficulties.sort()
+    for difficulty in difficulties:
+        best_score_lines.append("%s: %s" % [difficulty, ProfileManager.best_score[difficulty]])
+    if best_score_lines.is_empty():
+        best_score_lines.append("No scores recorded yet.")
+    best_score_label.text = "\n".join(best_score_lines)
+
+    var totals := ProfileManager.totals
+    var matches := totals.get("matches", {})
+    var photos := totals.get("photos", {})
+    totals_label.text = "Matches - Correct: %s, False: %s, Missed: %s\nPhotos - Good: %s / %s" % [
+        matches.get("correct", 0),
+        matches.get("false", 0),
+        matches.get("missed", 0),
+        photos.get("good", 0),
+        photos.get("total", 0),
+    ]

--- a/scripts/Scanner.gd
+++ b/scripts/Scanner.gd
@@ -1,0 +1,42 @@
+extends Node
+class_name Scanner
+
+## Simulates holding a scan over a subject until completion.
+
+signal scan_started(subject: Dictionary)
+signal scan_completed(subject: Dictionary)
+
+@export var scan_duration_seconds := 3.0
+var _scanning := false
+var _timer := 0.0
+var _subject: Dictionary = {}
+
+func _ready() -> void:
+    set_process(false)
+
+func begin_scan(subject: Dictionary) -> void:
+    if _scanning:
+        return
+    _scanning = true
+    _subject = subject
+    _timer = scan_duration_seconds
+    set_process(true)
+    scan_started.emit(subject)
+
+func cancel_scan() -> void:
+    if not _scanning:
+        return
+    _scanning = false
+    _subject = {}
+    _timer = 0.0
+    set_process(false)
+
+func _process(delta: float) -> void:
+    if not _scanning:
+        return
+    _timer = max(0.0, _timer - delta)
+    if _timer == 0.0:
+        _scanning = false
+        set_process(false)
+        scan_completed.emit(_subject)
+        _subject = {}

--- a/scripts/SettingsPanel.gd
+++ b/scripts/SettingsPanel.gd
@@ -1,0 +1,40 @@
+extends Control
+class_name SettingsPanel
+
+## Simple surface for adjusting placeholder settings.
+
+@onready var difficulty_option: OptionButton = $MarginContainer/VBoxContainer/DifficultyRow/DifficultyOption
+@onready var crowd_slider: HSlider = $MarginContainer/VBoxContainer/CrowdRow/CrowdSlider
+@onready var fullscreen_checkbox: CheckBox = $MarginContainer/VBoxContainer/FullscreenRow/FullscreenCheckBox
+
+const DIFFICULTIES := ["Easy", "Normal", "Hard", "Nightmare"]
+
+func _ready() -> void:
+    visible = false
+    _populate_difficulty()
+    _sync_from_settings()
+    difficulty_option.item_selected.connect(_on_difficulty_selected)
+    crowd_slider.value_changed.connect(_on_crowd_changed)
+    fullscreen_checkbox.toggled.connect(_on_fullscreen_toggled)
+
+func _populate_difficulty() -> void:
+    difficulty_option.clear()
+    for difficulty in DIFFICULTIES:
+        difficulty_option.add_item(difficulty)
+
+func _sync_from_settings() -> void:
+    var index := DIFFICULTIES.find(GameSettings.difficulty)
+    if index == -1:
+        index = DIFFICULTIES.find("Normal")
+    difficulty_option.select(max(0, index))
+    crowd_slider.value = GameSettings.crowd_size
+    fullscreen_checkbox.button_pressed = GameSettings.full_screen
+
+func _on_difficulty_selected(index: int) -> void:
+    GameSettings.set_difficulty(difficulty_option.get_item_text(index))
+
+func _on_crowd_changed(value: float) -> void:
+    GameSettings.set_crowd_size(int(value))
+
+func _on_fullscreen_toggled(pressed: bool) -> void:
+    GameSettings.set_full_screen(pressed)

--- a/scripts/SnapshotManager.gd
+++ b/scripts/SnapshotManager.gd
@@ -1,0 +1,13 @@
+extends Node
+class_name SnapshotManager
+
+## Evaluates screenshots taken during a shift.
+
+signal snapshot_taken(score: int)
+
+func capture_snapshot(subject: Dictionary) -> void:
+    # Placeholder scoring logic. Real implementation will consider framing,
+    # timing, and target accuracy.
+    var score := 10 if subject.is_empty() == false else 0
+    snapshot_taken.emit(score)
+    ProfileManager.record_photo(score > 0)

--- a/scripts/StaticOverlay.gd
+++ b/scripts/StaticOverlay.gd
@@ -1,0 +1,9 @@
+extends ColorRect
+class_name StaticOverlay
+
+## Placeholder for the static flicker effect when switching cameras.
+
+func flash() -> void:
+    visible = true
+    await get_tree().create_timer(0.1).timeout
+    visible = false

--- a/scripts/SummaryPanel.gd
+++ b/scripts/SummaryPanel.gd
@@ -1,0 +1,10 @@
+extends Control
+class_name SummaryPanel
+
+## Displays end-of-shift results.
+
+@onready var label: Label = $MarginContainer/VBoxContainer/SummaryLabel
+
+func show_summary() -> void:
+    visible = true
+    label.text = "Summary not yet implemented"

--- a/scripts/TargetManager.gd
+++ b/scripts/TargetManager.gd
@@ -1,0 +1,20 @@
+extends Node
+class_name TargetManager
+
+## Maintains the current HQ-issued target information.
+
+signal target_changed(target: Dictionary)
+
+var _active_target: Dictionary = {}
+
+@onready var npc_spawner: NPCSpawner = get_node_or_null("../NPCSpawner")
+
+func pick_new_target() -> void:
+    if not npc_spawner:
+        push_warning("TargetManager requires an NPCSpawner sibling.")
+        return
+    _active_target = npc_spawner.get_random_subject()
+    target_changed.emit(_active_target)
+
+func get_active_target() -> Dictionary:
+    return _active_target

--- a/scripts/Title.gd
+++ b/scripts/Title.gd
@@ -1,0 +1,23 @@
+extends Control
+class_name Title
+
+## Simple title screen with a start button stub.
+
+@onready var start_button: Button = $MarginContainer/VBoxContainer/StartButton
+@onready var settings_button: Button = $MarginContainer/VBoxContainer/SettingsButton
+@onready var quit_button: Button = $MarginContainer/VBoxContainer/QuitButton
+@onready var settings_panel: SettingsPanel = $SettingsPanelInstance
+
+func _ready() -> void:
+    start_button.pressed.connect(_on_start_pressed)
+    settings_button.pressed.connect(_on_settings_pressed)
+    quit_button.pressed.connect(_on_quit_pressed)
+
+func _on_start_pressed() -> void:
+    get_tree().change_scene_to_file("res://scenes/Main.tscn")
+
+func _on_settings_pressed() -> void:
+    settings_panel.visible = not settings_panel.visible
+
+func _on_quit_pressed() -> void:
+    get_tree().quit()

--- a/ui/ControlsOverlay.tscn
+++ b/ui/ControlsOverlay.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ControlsOverlay.gd" id="1"]
+
+[node name="ControlsOverlay" type="Control"]
+anchor_right = 0.35
+anchor_bottom = 0.6
+script = ExtResource("1")
+visible = false
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 16
+custom_constants/margin_top = 16
+custom_constants/margin_right = 16
+custom_constants/margin_bottom = 16
+
+[node name="Label" type="Label" parent="Panel/MarginContainer"]
+autowrap_mode = 2
+text = "Controls overlay placeholder"

--- a/ui/HUD.tscn
+++ b/ui/HUD.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/HUD.gd" id="1"]
+
+[node name="HUD" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 16.0
+offset_top = 16.0
+offset_right = -16.0
+offset_bottom = -16.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_vertical = 3
+
+[node name="TimerLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+text = "00:00"
+vertical_alignment = 1
+
+[node name="MessageLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+text = "Awaiting HQ directive"
+autowrap_mode = 2

--- a/ui/MiniMap.tscn
+++ b/ui/MiniMap.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/MiniMap.gd" id="1"]
+
+[node name="MiniMap" type="Control"]
+anchor_right = 0.3
+anchor_bottom = 0.3
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 8
+custom_constants/margin_top = 8
+custom_constants/margin_right = 8
+custom_constants/margin_bottom = 8
+
+[node name="GridContainer" type="GridContainer" parent="MarginContainer"]
+columns = 3
+
+[node name="Camera0" type="Button" parent="MarginContainer/GridContainer"]
+text = "1"
+toggle_mode = true
+
+[node name="Camera1" type="Button" parent="MarginContainer/GridContainer"]
+text = "2"
+toggle_mode = true
+
+[node name="Camera2" type="Button" parent="MarginContainer/GridContainer"]
+text = "3"
+toggle_mode = true
+
+[node name="Camera3" type="Button" parent="MarginContainer/GridContainer"]
+text = "4"
+toggle_mode = true
+
+[node name="Camera4" type="Button" parent="MarginContainer/GridContainer"]
+text = "5"
+toggle_mode = true
+
+[node name="Camera5" type="Button" parent="MarginContainer/GridContainer"]
+text = "6"
+toggle_mode = true
+
+[node name="Camera6" type="Button" parent="MarginContainer/GridContainer"]
+text = "7"
+toggle_mode = true
+
+[node name="Camera7" type="Button" parent="MarginContainer/GridContainer"]
+text = "8"
+toggle_mode = true
+
+[node name="Camera8" type="Button" parent="MarginContainer/GridContainer"]
+text = "9"
+toggle_mode = true

--- a/ui/PauseMenu.tscn
+++ b/ui/PauseMenu.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/PauseMenu.gd" id="1"]
+
+[node name="PauseMenu" type="Control"]
+anchor_right = 0.3
+anchor_bottom = 0.5
+script = ExtResource("1")
+visible = false
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 16
+custom_constants/margin_top = 16
+custom_constants/margin_right = 16
+custom_constants/margin_bottom = 16
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer"]
+size_flags_vertical = 3
+separation = 12
+
+[node name="ResumeButton" type="Button" parent="Panel/MarginContainer/VBoxContainer"]
+text = "Resume"
+
+[node name="SettingsButton" type="Button" parent="Panel/MarginContainer/VBoxContainer"]
+text = "Settings"
+
+[node name="ControlsButton" type="Button" parent="Panel/MarginContainer/VBoxContainer"]
+text = "Controls"
+
+[node name="QuitButton" type="Button" parent="Panel/MarginContainer/VBoxContainer"]
+text = "Quit to Desktop"

--- a/ui/ProfilePanel.tscn
+++ b/ui/ProfilePanel.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ProfilePanel.gd" id="1"]
+
+[node name="ProfilePanel" type="Control"]
+anchor_right = 0.35
+anchor_bottom = 0.5
+script = ExtResource("1")
+visible = false
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 16
+custom_constants/margin_top = 16
+custom_constants/margin_right = 16
+custom_constants/margin_bottom = 16
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer"]
+size_flags_vertical = 3
+separation = 12
+
+[node name="TitleLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+text = "Profile"
+
+[node name="BestScoreLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+autowrap_mode = 2
+text = "Best scores will appear here."
+
+[node name="TotalsLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+autowrap_mode = 2
+text = "Match and photo totals will appear here."

--- a/ui/SettingsPanel.tscn
+++ b/ui/SettingsPanel.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/SettingsPanel.gd" id="1"]
+
+[node name="SettingsPanel" type="Control"]
+anchor_right = 0.35
+anchor_bottom = 0.6
+script = ExtResource("1")
+visible = false
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 16
+custom_constants/margin_top = 16
+custom_constants/margin_right = 16
+custom_constants/margin_bottom = 16
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer"]
+size_flags_vertical = 3
+separation = 12
+
+[node name="TitleLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+text = "Settings"
+
+[node name="DifficultyRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
+size_flags_horizontal = 3
+
+[node name="DifficultyLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DifficultyRow"]
+text = "Difficulty"
+size_flags_horizontal = 1
+
+[node name="DifficultyOption" type="OptionButton" parent="Panel/MarginContainer/VBoxContainer/DifficultyRow"]
+size_flags_horizontal = 3
+
+[node name="CrowdRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
+size_flags_horizontal = 3
+
+[node name="CrowdLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/CrowdRow"]
+text = "Crowd"
+size_flags_horizontal = 1
+
+[node name="CrowdSlider" type="HSlider" parent="Panel/MarginContainer/VBoxContainer/CrowdRow"]
+size_flags_horizontal = 3
+min_value = 1.0
+max_value = 30.0
+step = 1.0
+value = 10.0
+
+[node name="FullscreenRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
+size_flags_horizontal = 3
+
+[node name="FullscreenLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/FullscreenRow"]
+text = "Fullscreen"
+size_flags_horizontal = 1
+
+[node name="FullscreenCheckBox" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/FullscreenRow"]
+text = "Enabled"
+size_flags_horizontal = 3

--- a/ui/StaticOverlay.tscn
+++ b/ui/StaticOverlay.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/StaticOverlay.gd" id="1"]
+
+[node name="StaticOverlay" type="ColorRect"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(1, 1, 1, 0.15)
+visible = false
+script = ExtResource("1")

--- a/ui/SummaryPanel.tscn
+++ b/ui/SummaryPanel.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/SummaryPanel.gd" id="1"]
+
+[node name="SummaryPanel" type="Control"]
+anchor_right = 0.4
+anchor_bottom = 0.6
+script = ExtResource("1")
+visible = false
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 16
+custom_constants/margin_top = 16
+custom_constants/margin_right = 16
+custom_constants/margin_bottom = 16
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer"]
+size_flags_vertical = 3
+separation = 12
+
+[node name="SummaryLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+text = "Summary"
+autowrap_mode = 2


### PR DESCRIPTION
## Summary
- configure the project to boot into a title screen, register settings/profile autoloads, and load a starter audio bus layout
- add core gameplay and UI scenes with placeholder scripts for camera switching, crowds, scanning, HUD, pause, settings, and profile panels
- include persistence scaffolding for user settings and profile data to anchor future gameplay logic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3beeab3b48330bb386451cacd7b6e