### PR TITLE
Remove conflicting GameSettings class name

### DIFF
--- a/scripts/GameSettings.gd
+++ b/scripts/GameSettings.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name GameSettings
 
 ## Autoload responsible for storing and applying runtime settings.
 ##


### PR DESCRIPTION
## Summary
- remove the `class_name GameSettings` declaration so the autoload singleton name no longer conflicts with a global class

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3c23ae798833080f28967d4184f0d